### PR TITLE
Install directly from GitHub

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 import elemental
 
 
-with open("README.rst", "r") as f:
+with open("README.rst", "r", encoding="utf-8") as f:
     LONG_DESCRIPTION = f.read()
 
 


### PR DESCRIPTION
There seems to be some utf-8 in your Readme.rst:

(cedars) root@cedars:/srv/project/cedars# pip install -U -r ../requirements_bdd.txt 
Collecting elemental_from_github
  Cloning https://github.com/red-and-black/elemental.git to /tmp/pip-install-xuhiz4rw/elemental-from-github
    ERROR: Command errored out with exit status 1:
     command: /webapps/cedars/bin/python3.6 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-xuhiz4rw/elemental-from-github/setup.py'"'"'; __file__='"'"'/tmp/pip-install-xuhiz4rw/elemental-from-github/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-7_6mxum7
         cwd: /tmp/pip-install-xuhiz4rw/elemental-from-github/
    Complete output (7 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-xuhiz4rw/elemental-from-github/setup.py", line 7, in <module>
        LONG_DESCRIPTION = f.read()
      File "/webapps/cedars/lib/python3.6/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 1363: ordinal not in range(128)
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
(cedars) root@cedars:/srv/project/cedars# 
