### PR TITLE
#11: Limit version of Selenium

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setuptools.setup(
     ],
     keywords="selenium, testing",
     install_requires=[
-        "selenium>=3.141",
+        "selenium>=3.141, <4.10",
     ],
     python_requires=">=3.5",
 )


### PR DESCRIPTION
Selenium version 4.10 removes the keyword `executable_path` from its WebDriver.